### PR TITLE
Spring Boot 2.0.0.M3 upgrade related changes

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -4,7 +4,7 @@ Brian Clozel, Violeta Georgieva - Pivotal
 :source-highlighter: prettify
 :icons: font
 :toc: 
-:spring-boot-version: 2.0.0.M1
+:spring-boot-version: 2.0.0.M3
 :spring-framework-version: 5.0.0.RC1
 :spring-framework-doc-base: http://docs.spring.io/spring-framework/docs/{spring-framework-version}
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -498,7 +498,7 @@ and <a href="http://docs.spring.io/spring-framework/docs/5.0.0.RC1/javadoc-api/"
 <div class="sect2">
 <h3 id="_create_this_application"><a class="anchor" href="#_create_this_application"></a>Create this application</h3>
 <div class="paragraph">
-<p>Go to <code><a href="https://start.spring.io" class="bare">https://start.spring.io</a></code> and create a Maven project with Spring Boot 2.0.0.M1,
+<p>Go to <code><a href="https://start.spring.io" class="bare">https://start.spring.io</a></code> and create a Maven project with Spring Boot 2.0.0.M3,
 with groupId <code>io.spring.workshop</code> and artifactId <code>stock-quotes</code>. Select the <code>Reactive Web</code>
 Boot starter.
 Unzip the given file into a directory and import that application into your IDE.</p>
@@ -907,7 +907,7 @@ public class StockQuotesApplicationTests {
 <div class="sect2">
 <h3 id="_create_this_application_2"><a class="anchor" href="#_create_this_application_2"></a>Create this application</h3>
 <div class="paragraph">
-<p>Go to <code><a href="https://start.spring.io" class="bare">https://start.spring.io</a></code> and create a Maven project with Spring Boot 2.0.0.M1,
+<p>Go to <code><a href="https://start.spring.io" class="bare">https://start.spring.io</a></code> and create a Maven project with Spring Boot 2.0.0.M3,
 with groupId <code>io.spring.workshop</code> and artifactId <code>trading-service</code>. Select the <code>Reactive Web</code>
 , <code>Devtools</code>, <code>Thymeleaf</code> and <code>Reactive Mongo</code> Boot starters.
 Unzip the given file into a directory and import that application into your IDE.</p>

--- a/stock-quotes/pom.xml
+++ b/stock-quotes/pom.xml
@@ -14,8 +14,8 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.0.M1</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<version>2.0.0.M3</version>
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>

--- a/stock-quotes/src/test/java/io/spring/workshop/stockquotes/StockQuotesApplicationTests.java
+++ b/stock-quotes/src/test/java/io/spring/workshop/stockquotes/StockQuotesApplicationTests.java
@@ -35,7 +35,8 @@ public class StockQuotesApplicationTests {
 				.hasSize(20)
 				// Here we check that all Quotes have a positive price value
 				.consumeWith(allQuotes ->
-						assertThat(allQuotes).allSatisfy(quote -> assertThat(quote.getPrice()).isPositive()));
+						assertThat(allQuotes.getResponseBody())
+							.allSatisfy(quote -> assertThat(((Quote) quote).getPrice()).isPositive()));
 	}
 
 }

--- a/trading-service/pom.xml
+++ b/trading-service/pom.xml
@@ -14,8 +14,8 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.0.M1</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<version>2.0.0.M3</version>
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>


### PR DESCRIPTION
The Spring initializer now is 2.0.0.M3 so added updates for that.
 - The main being EntityExchangeResult getResponseBody() method needs to be called in the StockQuotesApplicationTests.java class
 - The other updates are for version upgrade in the pom and the readme files